### PR TITLE
Add skeleton React frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,25 @@
+# S&P 500 Portfolio Frontend
+
+This is a minimal React application that visualizes portfolio data from the backend.
+
+## Available Pages
+
+- **History** – shows allocation and prediction history
+- **Current** – displays the latest portfolio allocation
+- **Growth Overview** – charts performance over time
+
+## Development
+
+```bash
+cd frontend
+npm install   # install dependencies
+npm start     # run the development server
+```
+
+The application expects API endpoints to be served from the Flask backend:
+
+- `/api/history`
+- `/api/current`
+- `/api/growth`
+
+These endpoints should return JSON data compatible with the components in `src/pages`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "sp500-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.4",
+    "react-scripts": "^5.0.1",
+    "chart.js": "^4.4.0",
+    "react-chartjs-2": "^5.2.0"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SP500 Portfolio Manager</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Routes, Route, Link } from 'react-router-dom';
+import History from './pages/History';
+import Current from './pages/Current';
+import GrowthOverview from './pages/GrowthOverview';
+
+function App() {
+  return (
+    <div>
+      <nav>
+        <Link to="/">Current</Link>
+        <Link to="/history">History</Link>
+        <Link to="/growth">Growth Overview</Link>
+      </nav>
+      <main>
+        <Routes>
+          <Route path="/" element={<Current />} />
+          <Route path="/history" element={<History />} />
+          <Route path="/growth" element={<GrowthOverview />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,20 @@
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  background-color: #f7f7f7;
+}
+
+nav {
+  background: #222;
+  padding: 0.5rem 1rem;
+}
+
+nav a {
+  color: #fff;
+  margin-right: 1rem;
+  text-decoration: none;
+}
+
+main {
+  padding: 1rem;
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
+);

--- a/frontend/src/pages/Current.js
+++ b/frontend/src/pages/Current.js
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react';
+
+function Current() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/current')
+      .then((res) => res.json())
+      .then(setData)
+      .catch(() => setData(null));
+  }, []);
+
+  if (!data) {
+    return <p>Loading current allocation...</p>;
+  }
+
+  return (
+    <div>
+      <h2>Current Allocation</h2>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}
+
+export default Current;

--- a/frontend/src/pages/GrowthOverview.js
+++ b/frontend/src/pages/GrowthOverview.js
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  LineElement,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(LineElement, CategoryScale, LinearScale, PointElement, Tooltip, Legend);
+
+function GrowthOverview() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/growth')
+      .then((res) => res.json())
+      .then(setData)
+      .catch(() => setData(null));
+  }, []);
+
+  if (!data) {
+    return <p>Loading growth data...</p>;
+  }
+
+  const chartData = {
+    labels: data.dates,
+    datasets: [
+      {
+        label: 'Portfolio Value',
+        data: data.values,
+        fill: false,
+        borderColor: 'rgb(75, 192, 192)',
+      },
+    ],
+  };
+
+  return (
+    <div>
+      <h2>Growth Overview</h2>
+      <Line data={chartData} />
+    </div>
+  );
+}
+
+export default GrowthOverview;

--- a/frontend/src/pages/History.js
+++ b/frontend/src/pages/History.js
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react';
+
+function History() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/history')
+      .then((res) => res.json())
+      .then(setData)
+      .catch(() => setData(null));
+  }, []);
+
+  if (!data) {
+    return <p>Loading history...</p>;
+  }
+
+  return (
+    <div>
+      <h2>Prediction History</h2>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}
+
+export default History;


### PR DESCRIPTION
## Summary
- add basic React frontend with History, Current, and Growth pages
- document setup and expected API routes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851db822a3c83259712c2c79fb467e1