### PR TITLE
Update README with frontend instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,4 +102,16 @@ python fetch_analyst_labels.py
 
 ---
 
-Let me know if you want a script to automate all of this, or if you hit any errors along the way!
+## Frontend React App
+
+A small React application is located in the `frontend/` directory and visualizes portfolio data from the API.
+
+Run it with:
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+The app expects endpoints from a Flask backend such as `/api/history`, `/api/current`, and `/api/growth`. See [frontend/README.md](frontend/README.md) for details.


### PR DESCRIPTION
## Summary
- remove trailing prompt text from `README.md`
- describe the React app in `frontend`
- show how to start the frontend and mention the Flask backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e69c79c08325aeb0698297c68146