### PR TITLE
Add React proxy to frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,6 +16,9 @@ npm install   # install dependencies
 npm start     # run the development server
 ```
 
+The React dev server is configured to proxy API requests to `http://localhost:5000`.
+Make sure the Flask backend is running on that port (update `package.json` if it uses a different port).
+
 The application expects API endpoints to be served from the Flask backend:
 
 - `/api/history`

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "sp500-frontend",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:5000",
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
## Summary
- configure React dev server to proxy to Flask on port 5000
- document backend URL in frontend README

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e69d704c8325ad9bfa5d4abfa439