### PR TITLE
Update backend service config

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Make sure it contains:
 ```
 DATABASE_URL=postgresql://manovay:Padhai007@localhost:1111/sp500_db
 FMP_API_KEY=your_fmp_api_key_here
+DB_HOST=postgres
+DB_PORT=5432
+DB_USER=manovay
+DB_PASSWORD=Padhai007
+DB_NAME=sp500_db
+ADMIN_TOKEN=choose_a_secret
 ```
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,23 @@ services:
     networks:
       - sp500_net                      # Connect to the custom network
 
+  sp500-backend: # NEW SERVICE BLOCK
+    container_name: sp500-backend # NEW SERVICE BLOCK
+    build: ./backend # NEW SERVICE BLOCK
+    depends_on: # NEW SERVICE BLOCK
+      - postgres # NEW SERVICE BLOCK
+    environment: # NEW SERVICE BLOCK
+      DB_HOST: postgres # NEW SERVICE BLOCK
+      DB_PORT: 5432 # NEW SERVICE BLOCK
+      DB_USER: ${DB_USER:-manovay} # NEW SERVICE BLOCK (match postgres credentials)
+      DB_PASSWORD: ${DB_PASSWORD:-Padhai007} # NEW SERVICE BLOCK
+      DB_NAME: ${DB_NAME:-sp500_db} # NEW SERVICE BLOCK
+      ADMIN_TOKEN: ${ADMIN_TOKEN} # NEW SERVICE BLOCK
+    ports: # NEW SERVICE BLOCK
+      - "5000:5000" # NEW SERVICE BLOCK
+    networks: # NEW SERVICE BLOCK
+      - sp500_net # NEW SERVICE BLOCK
+
   # pgAdmin service for managing PostgreSQL
   pgadmin:
     image: dpage/pgadmin4


### PR DESCRIPTION
## Summary
- fix build path for sp500-backend service
- use defaults for DB_ variables in docker-compose
- document DB_ variables in README

## Testing
- `python - <<'PY'
import yaml
with open('docker-compose.yml') as f:
    yaml.safe_load(f)
print('ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_687bf7f5e2788325aa24b802b500b191